### PR TITLE
fix: error handling was bad

### DIFF
--- a/compressor/lib.go
+++ b/compressor/lib.go
@@ -25,7 +25,7 @@ func AsReader(input io.ReadCloser) io.Reader {
 		// however, the standard library's version checks the underlying
 		// types of the Readers and Writers for optimized method calls
 		if _, err := io.Copy(gzipWriter, input); err != nil {
-			panic(err)
+			pipeWriter.CloseWithError(err)
 		}
 	}()
 	return pipeReader


### PR DESCRIPTION
Previously, I allowed the err to panic during the copy. This was a mistake because we could still handle the error gracefully while closing the pipe. This test validates that correct error handling is being done.